### PR TITLE
Add Claude Code plugin marketplace configuration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,45 @@
+{
+  "name": "open-science-skills",
+  "metadata": {
+    "description": "Community-contributed domain skills for scientific discovery with Claude Code and other AI agents",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "data-science",
+      "description": "Statistical analysis strategies and data exploration techniques",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./data-science"
+      ]
+    },
+    {
+      "name": "genomics",
+      "description": "Genomics and transcriptomics analysis strategies",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./genomics"
+      ]
+    },
+    {
+      "name": "metabolomics",
+      "description": "Metabolomics-specific analysis strategies and domain knowledge",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./metabolomics"
+      ]
+    },
+    {
+      "name": "structural-biology",
+      "description": "Structural biology analysis including protein structure validation, AlphaFold interpretation, and structural comparisons",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./structural-biology"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ Skills are modular capabilities that extend Claude's functionality with domain-s
 
 ## Installation
 
+### Option 1: Marketplace (Recommended)
+
+Register this repository as a Claude Code plugin marketplace, then browse and install skills:
+
+```bash
+# Add the marketplace
+/plugin marketplace add justaddcoffee/open-science-skills
+
+# Browse available skills
+/plugin marketplace browse open-science-skills
+
+# Install individual skills
+/plugin install open-science-skills:data-science
+/plugin install open-science-skills:genomics
+/plugin install open-science-skills:metabolomics
+/plugin install open-science-skills:structural-biology
+```
+
+### Option 2: Manual Installation
+
 Clone this repository into your Claude Code skills directory:
 
 ```bash


### PR DESCRIPTION
## Summary
- Add `.claude-plugin/marketplace.json` to enable this repository to be used as a Claude Code plugin marketplace
- Update README.md to document marketplace installation as the recommended method (with manual installation as fallback)
- Users can now install skills with simple commands like `/plugin marketplace add justaddcoffee/open-science-skills`

## Test plan
- [ ] Verify marketplace.json is valid JSON
- [ ] Test marketplace registration with `/plugin marketplace add justaddcoffee/open-science-skills`
- [ ] Test skill installation with `/plugin install open-science-skills:data-science`

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)